### PR TITLE
feat: configuracion de cuota por hermanos

### DIFF
--- a/CUOTA_POR_HERMANOS_FEATURE.md
+++ b/CUOTA_POR_HERMANOS_FEATURE.md
@@ -1,0 +1,127 @@
+¡Por supuesto! Aquí tienes un archivo Markdown explicando el uso del CRUD para la entidad **CuotaPorHermanos** y cómo se integra en la lógica de actualización de balances familiares.
+
+---
+
+# Configuración y Uso de Cuotas por Hermanos
+
+## ¿Qué es CuotaPorHermanos?
+
+La entidad **CuotaPorHermanos** permite definir el valor de la cuota mensual a descontar del balance de una familia según la cantidad de usuarios activos (hermanos) que tenga. Esta configuración es editable por Tesorería, sin necesidad de modificar el código fuente.
+
+---
+
+## Endpoints Disponibles
+
+La API expone un CRUD completo para gestionar la configuración de cuotas por cantidad de hermanos.
+
+### Crear una nueva configuración
+
+```http
+POST /cuota-por-hermanos
+Content-Type: application/json
+
+{
+  "cantidad": 2,
+  "valor": 8000
+}
+```
+- **cantidad**: Número de usuarios activos (hermanos).
+- **valor**: Valor de la cuota para esa cantidad.
+
+---
+
+### Listar todas las configuraciones
+
+```http
+GET /cuota-por-hermanos
+```
+**Respuesta:**
+```json
+[
+  { "id": "uuid1", "cantidad": 1, "valor": 5000, ... },
+  { "id": "uuid2", "cantidad": 2, "valor": 8000, ... }
+]
+```
+
+---
+
+### Obtener una configuración específica
+
+```http
+GET /cuota-por-hermanos/:id
+```
+
+---
+
+### Actualizar el valor de una cuota
+
+```http
+PATCH /cuota-por-hermanos/:id
+Content-Type: application/json
+
+{
+  "valor": 9000
+}
+```
+
+---
+
+### Eliminar una configuración
+
+```http
+DELETE /cuota-por-hermanos/:id
+```
+
+---
+
+## ¿Cómo se usa en la lógica de balance?
+
+Cuando se actualiza el balance de una familia, el sistema:
+
+1. **Cuenta los usuarios activos** en la familia.
+2. **Busca el valor de cuota** correspondiente en la tabla `CuotaPorHermanos` según la cantidad de usuarios activos.
+3. **Aplica la fórmula**:
+   ```
+   montoADescontar = valorCuota * cantidadUsuariosActivos * 0.8
+   ```
+4. **Actualiza el balance** restando el monto calculado.
+
+> Si no existe configuración para cierta cantidad, se puede usar un valor por defecto (ejemplo: 0).
+
+**Ejemplo de código relevante:**  
+[balance.service.ts](file:///C:/Users/Stefano/Repos/GitHub/tesoreria-api/src/balance/balance.service.ts)
+```typescript
+const cantidadActivos = family.users.filter(u => u.is_active).length;
+let cuotaConfig = await this.prisma.cuotaPorHermanos.findFirst({
+  where: { cantidad: cantidadActivos },
+});
+const valorCuota = cuotaConfig?.valor ?? 0;
+const montoADescontar = valorCuota * cantidadActivos * 0.8;
+```
+
+---
+
+## Ventajas de este enfoque
+
+- **Editable por Tesorería**: No requiere cambios de código ni deploys.
+- **Flexible**: Permite agregar, modificar o eliminar reglas para cualquier cantidad de hermanos.
+- **Centralizado**: Toda la lógica de cálculo de cuotas depende de esta configuración.
+
+---
+
+## Consideraciones
+
+- Si una familia tiene una cuota personalizada (`is_custom_cuota`), se ignora esta lógica y se usa el valor personalizado.
+- Si no existe configuración para cierta cantidad de usuarios, se puede definir un valor por defecto o lanzar un error según la necesidad del negocio.
+
+---
+
+## Resumen
+
+- Usa los endpoints REST para gestionar la configuración de cuotas por cantidad de hermanos.
+- El sistema aplica automáticamente la fórmula al actualizar balances familiares.
+- Tesorería puede modificar los valores en cualquier momento desde el frontend o herramientas administrativas.
+
+---
+
+¿Dudas o sugerencias? ¡No dudes en consultarnos!

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,7 +70,7 @@ model Family {
   createdAt    DateTime       @default(now())
   updatedAt    DateTime       @updatedAt
   name         String
-  phone        String?
+  phone        String
   manage_by    String
   balance      Balance        @relation(fields: [id_balance], references: [id])
   payments     Payment[]
@@ -108,6 +108,14 @@ model Cuota {
   updatedAt DateTime @updatedAt
   value     Float
   is_active Boolean  @default(true)
+}
+
+model CuotaPorHermanos {
+  id        String   @id @default(uuid())
+  cantidad  Int      // cantidad de usuarios activos
+  valor     Float    // valor de cuota base para esa cantidad
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Cfa {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { FamilyModule } from './family/family.module';
 import { RamaModule } from './rama/rama.module';
 import { FolderModule } from './folder/folder.module';
 import { CuotaModule } from './cuota/cuota.module';
+import { CuotaPorHermanosModule } from './cuota-por-hermanos/cuota-por-hermanos.module';
 import { BalanceModule } from './balance/balance.module';
 import { UserController } from './user/user.controller';
 import { UserService } from './user/user.service';
@@ -25,6 +26,7 @@ import { FileModule } from './file/file.module';
     RamaModule,
     FolderModule,
     CuotaModule,
+    CuotaPorHermanosModule,
     BalanceModule,
     UserModule,
     FamilyModule,

--- a/src/cuota-por-hermanos/cuota-por-hermanos.controller.ts
+++ b/src/cuota-por-hermanos/cuota-por-hermanos.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { CuotaPorHermanosService } from './cuota-por-hermanos.service';
+import { CreateCuotaPorHermanosDto, UpdateCuotaPorHermanosDto } from './dto/cuota-por-hermanos.dto';
+
+@Controller('cuota-por-hermanos')
+export class CuotaPorHermanosController {
+  constructor(private readonly service: CuotaPorHermanosService) {}
+
+  @Post()
+  create(@Body() dto: CreateCuotaPorHermanosDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateCuotaPorHermanosDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/src/cuota-por-hermanos/cuota-por-hermanos.module.ts
+++ b/src/cuota-por-hermanos/cuota-por-hermanos.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CuotaPorHermanosService } from './cuota-por-hermanos.service';
+import { CuotaPorHermanosController } from './cuota-por-hermanos.controller';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [CuotaPorHermanosController],
+  providers: [CuotaPorHermanosService, PrismaService],
+  exports: [CuotaPorHermanosService],
+})
+export class CuotaPorHermanosModule {}

--- a/src/cuota-por-hermanos/cuota-por-hermanos.service.ts
+++ b/src/cuota-por-hermanos/cuota-por-hermanos.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { CreateCuotaPorHermanosDto, UpdateCuotaPorHermanosDto } from './dto/cuota-por-hermanos.dto';
+
+@Injectable()
+export class CuotaPorHermanosService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(data: CreateCuotaPorHermanosDto) {
+    // Evitar duplicados
+    const exists = await this.prisma.cuotaPorHermanos.findFirst({ where: { cantidad: data.cantidad } });
+    if (exists) throw new ConflictException('Ya existe una cuota para esa cantidad de hermanos');
+    return this.prisma.cuotaPorHermanos.create({ data });
+  }
+
+  async findAll() {
+    return this.prisma.cuotaPorHermanos.findMany({ orderBy: { cantidad: 'asc' } });
+  }
+
+  async findOne(id: string) {
+    const cuota = await this.prisma.cuotaPorHermanos.findUnique({ where: { id } });
+    if (!cuota) throw new NotFoundException('No encontrada');
+    return cuota;
+  }
+
+  async update(id: string, data: UpdateCuotaPorHermanosDto) {
+    await this.findOne(id); // Valida existencia
+    return this.prisma.cuotaPorHermanos.update({ where: { id }, data });
+  }
+
+  async remove(id: string) {
+    await this.findOne(id); // Valida existencia
+    return this.prisma.cuotaPorHermanos.delete({ where: { id } });
+  }
+}

--- a/src/cuota-por-hermanos/dto/cuota-por-hermanos.dto.ts
+++ b/src/cuota-por-hermanos/dto/cuota-por-hermanos.dto.ts
@@ -1,0 +1,17 @@
+import { IsInt, IsNumber, Min, IsNotEmpty } from 'class-validator';
+
+export class CreateCuotaPorHermanosDto {
+  @IsInt()
+  @Min(1)
+  cantidad: number;
+
+  @IsNumber()
+  @Min(0)
+  valor: number;
+}
+
+export class UpdateCuotaPorHermanosDto {
+  @IsNumber()
+  @Min(0)
+  valor: number;
+}


### PR DESCRIPTION

---

# Configuración y Uso de Cuotas por Hermanos

## ¿Qué es CuotaPorHermanos?

La entidad **CuotaPorHermanos** permite definir el valor de la cuota mensual a descontar del balance de una familia según la cantidad de usuarios activos (hermanos) que tenga. Esta configuración es editable por Tesorería, sin necesidad de modificar el código fuente.

---

## Endpoints Disponibles

La API expone un CRUD completo para gestionar la configuración de cuotas por cantidad de hermanos.

### Crear una nueva configuración

```http
POST /cuota-por-hermanos
Content-Type: application/json

{
  "cantidad": 2,
  "valor": 8000
}
```
- **cantidad**: Número de usuarios activos (hermanos).
- **valor**: Valor de la cuota para esa cantidad.

---

### Listar todas las configuraciones

```http
GET /cuota-por-hermanos
```
**Respuesta:**
```json
[
  { "id": "uuid1", "cantidad": 1, "valor": 5000, ... },
  { "id": "uuid2", "cantidad": 2, "valor": 8000, ... }
]
```

---

### Obtener una configuración específica

```http
GET /cuota-por-hermanos/:id
```

---

### Actualizar el valor de una cuota

```http
PATCH /cuota-por-hermanos/:id
Content-Type: application/json

{
  "valor": 9000
}
```

---

### Eliminar una configuración

```http
DELETE /cuota-por-hermanos/:id
```

---

## ¿Cómo se usa en la lógica de balance?

Cuando se actualiza el balance de una familia, el sistema:

1. **Cuenta los usuarios activos** en la familia.
2. **Busca el valor de cuota** correspondiente en la tabla `CuotaPorHermanos` según la cantidad de usuarios activos.
3. **Aplica la fórmula**:
   ```
   montoADescontar = valorCuota * cantidadUsuariosActivos * 0.8
   ```
4. **Actualiza el balance** restando el monto calculado.

> Si no existe configuración para cierta cantidad, se puede usar un valor por defecto (ejemplo: 0).

**Ejemplo de código relevante:**  
[balance.service.ts](file:///C:/Users/Stefano/Repos/GitHub/tesoreria-api/src/balance/balance.service.ts)
```typescript
const cantidadActivos = family.users.filter(u => u.is_active).length;
let cuotaConfig = await this.prisma.cuotaPorHermanos.findFirst({
  where: { cantidad: cantidadActivos },
});
const valorCuota = cuotaConfig?.valor ?? 0;
const montoADescontar = valorCuota * cantidadActivos * 0.8;
```

---

## Ventajas de este enfoque

- **Editable por Tesorería**: No requiere cambios de código ni deploys.
- **Flexible**: Permite agregar, modificar o eliminar reglas para cualquier cantidad de hermanos.
- **Centralizado**: Toda la lógica de cálculo de cuotas depende de esta configuración.

---

## Consideraciones

- Si una familia tiene una cuota personalizada (`is_custom_cuota`), se ignora esta lógica y se usa el valor personalizado.
- Si no existe configuración para cierta cantidad de usuarios, se puede definir un valor por defecto o lanzar un error según la necesidad del negocio.

---

## Resumen

- Usa los endpoints REST para gestionar la configuración de cuotas por cantidad de hermanos.
- El sistema aplica automáticamente la fórmula al actualizar balances familiares.
- Tesorería puede modificar los valores en cualquier momento desde el frontend o herramientas administrativas.

---

¿Dudas o sugerencias? ¡No dudes en consultarnos!