### PR TITLE
Feat: KPI cobrabilidad resumen y fix attachment en cuota familiar

### DIFF
--- a/src/cobrabilidad/cobrabilidad.controller.ts
+++ b/src/cobrabilidad/cobrabilidad.controller.ts
@@ -1,11 +1,9 @@
 import {
   Controller,
   Get,
-  Param,
   HttpCode,
   HttpStatus,
   UseGuards,
-  Request,
   Query,
   BadRequestException,
 } from '@nestjs/common';
@@ -13,7 +11,20 @@ import { CobrabilidadService } from './cobrabilidad.service';
 import { AuthGuard } from 'src/auth/guards/auth.guard';
 import { Roles } from 'src/auth/decorators/roles.decorator';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+} from '@nestjs/swagger';
+import {
+  GetCobrabilidadResumenQuery,
+  CobrabilidadResumenDto,
+} from './dto/cobrabilidad.dto';
 
+@ApiTags('stats/cobrabilidad')
+@ApiBearerAuth()
 @UseGuards(AuthGuard, RolesGuard)
 @Controller('stats/cobrabilidad')
 export class CobrabilidadController {
@@ -47,5 +58,35 @@ export class CobrabilidadController {
     } catch (error) {
       throw error;
     }
+  }
+
+  /**
+   * Devuelve el consolidado global de cobrabilidad de todas las ramas para el mes/año indicado.
+   */
+  @Get('resumen')
+  @Roles('MASTER', 'DIRIGENTE')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Resumen global de cobrabilidad del mes',
+    description:
+      'Retorna el total esperado, total cobrado y porcentaje de cobrabilidad consolidado de todas las ramas para un mes y año determinados.',
+  })
+  @ApiQuery({ name: 'month', required: true, description: 'Mes (1-12)', example: '5' })
+  @ApiQuery({ name: 'year', required: true, description: 'Año (YYYY)', example: '2025' })
+  @ApiResponse({
+    status: 200,
+    description: 'Resumen de cobrabilidad obtenido correctamente',
+    type: CobrabilidadResumenDto,
+  })
+  @ApiResponse({ status: 400, description: 'Parámetros month y/o year inválidos o faltantes' })
+  @ApiResponse({ status: 401, description: 'No autenticado' })
+  @ApiResponse({ status: 403, description: 'Sin permisos — solo MASTER y DIRIGENTE' })
+  async getResumenCobrabilidad(
+    @Query() query: GetCobrabilidadResumenQuery,
+  ): Promise<CobrabilidadResumenDto> {
+    const mesNum = parseInt(query.month, 10);
+    const anioNum = parseInt(query.year, 10);
+
+    return this.cobrabilidadService.getResumenCobrabilidad(mesNum, anioNum);
   }
 }

--- a/src/cobrabilidad/cobrabilidad.service.ts
+++ b/src/cobrabilidad/cobrabilidad.service.ts
@@ -6,6 +6,7 @@ import {
 import { PrismaService } from 'src/prisma.service';
 import { DateTime } from 'luxon';
 import { Balance, Family } from '@prisma/client';
+import { CobrabilidadResumenDto } from './dto/cobrabilidad.dto';
 
 @Injectable()
 export class CobrabilidadService {
@@ -117,6 +118,49 @@ export class CobrabilidadService {
       this.logger.error('❌ Error al calcular cobrabilidad', error);
       throw new InternalServerErrorException(
         'Error al calcular la cobrabilidad por rama',
+      );
+    }
+  }
+
+  async getResumenCobrabilidad(
+    mes: number,
+    anio: number,
+  ): Promise<CobrabilidadResumenDto> {
+    try {
+      const resultadosPorRama = await this.calcularCobrabilidadPorRama(
+        mes,
+        anio,
+      );
+
+      const totalEsperado = resultadosPorRama.reduce(
+        (acc, rama) => acc + rama.totalEsperado,
+        0,
+      );
+      const totalCobrado = resultadosPorRama.reduce(
+        (acc, rama) => acc + rama.totalCobrado,
+        0,
+      );
+
+      const cobrabilidad =
+        totalEsperado > 0
+          ? Number(((totalCobrado / totalEsperado) * 100).toFixed(1))
+          : 0;
+
+      this.logger.log(
+        `✅ Resumen de cobrabilidad calculado para ${mes}/${anio}: ${cobrabilidad}%`,
+      );
+
+      return {
+        totalEsperado: Number(totalEsperado.toFixed(2)),
+        totalCobrado: Number(totalCobrado.toFixed(2)),
+        cobrabilidad,
+        mes,
+        anio,
+      };
+    } catch (error) {
+      this.logger.error('❌ Error al calcular resumen de cobrabilidad', error);
+      throw new InternalServerErrorException(
+        'Error al calcular el resumen de cobrabilidad',
       );
     }
   }

--- a/src/cobrabilidad/dto/cobrabilidad.dto.ts
+++ b/src/cobrabilidad/dto/cobrabilidad.dto.ts
@@ -1,0 +1,38 @@
+import { IsNumberString, IsNotEmpty, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetCobrabilidadResumenQuery {
+  @ApiProperty({
+    description: 'Mes (1-12)',
+    example: '5',
+  })
+  @IsNumberString({}, { message: 'month debe ser un valor numérico' })
+  @IsNotEmpty({ message: 'month es requerido' })
+  @Matches(/^([1-9]|1[0-2])$/, { message: 'month debe ser un valor entre 1 y 12' })
+  month: string;
+
+  @ApiProperty({
+    description: 'Año (YYYY)',
+    example: '2025',
+  })
+  @IsNumberString({}, { message: 'year debe ser un valor numérico' })
+  @IsNotEmpty({ message: 'year es requerido' })
+  year: string;
+}
+
+export class CobrabilidadResumenDto {
+  @ApiProperty({ description: 'Total esperado de cobros en el mes', example: 50000 })
+  totalEsperado: number;
+
+  @ApiProperty({ description: 'Total efectivamente cobrado en el mes', example: 35000 })
+  totalCobrado: number;
+
+  @ApiProperty({ description: 'Porcentaje de cobrabilidad redondeado a 1 decimal', example: 70.0 })
+  cobrabilidad: number;
+
+  @ApiProperty({ description: 'Mes consultado (1-12)', example: 5 })
+  mes: number;
+
+  @ApiProperty({ description: 'Año consultado', example: 2025 })
+  anio: number;
+}

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -111,6 +111,7 @@ export class TransactionsService {
             category: 'CUOTA',
             concept,
             description: `Cuota mensual de la familia con ID ${data.id_family}`,
+            attachment: data.attachment,
           },
         }),
         this.prisma.balance.update({


### PR DESCRIPTION
- Agrega endpoint GET /stats/cobrabilidad/resumen con consolidado global por mes/año
- Persiste campo attachment en createFamilyTransaction (era descartado silenciosamente)