### PR TITLE
Feat: add monitoring module with data health check endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { CronJobsModule } from './cron-jobs/cron-jobs.module';
 import { FileModule } from './file/file.module';
 import { CobrabilidadModule } from './cobrabilidad/cobrabilidad.module';
 import { ActionLogsModule } from './action-logs/action-logs.module';
+import { MonitoringModule } from './monitoring/monitoring.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { ActionLogsModule } from './action-logs/action-logs.module';
     FileModule,
     CobrabilidadModule,
     ActionLogsModule,
+    MonitoringModule,
   ],
   controllers: [],
   providers: [],

--- a/src/monitoring/monitoring.controller.ts
+++ b/src/monitoring/monitoring.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, HttpCode, HttpStatus, Req, UseGuards } from '@nestjs/common';
+import { MonitoringService } from './monitoring.service';
+import { AuthGuard } from 'src/auth/guards/auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { Request as ExpressRequest } from 'express';
+import { LoggedUser } from 'src/auth/types';
+
+@UseGuards(AuthGuard, RolesGuard)
+@Controller('monitoring')
+export class MonitoringController {
+  constructor(private readonly monitoringService: MonitoringService) {}
+
+  @Get('health-check')
+  @Roles('MASTER', 'DIRIGENTE')
+  @HttpCode(HttpStatus.OK)
+  getHealthCheck(@Req() req: ExpressRequest) {
+    const user = (req as ExpressRequest & { user: LoggedUser }).user;
+    return this.monitoringService.getHealthCheck(user);
+  }
+}

--- a/src/monitoring/monitoring.module.ts
+++ b/src/monitoring/monitoring.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { MonitoringController } from './monitoring.controller';
+import { MonitoringService } from './monitoring.service';
+import { PrismaService } from 'src/prisma.service';
+import { AuthModule } from 'src/auth/auth.module';
+import { UserService } from 'src/user/user.service';
+import { JwtService } from '@nestjs/jwt';
+import { ServicesModule } from 'src/services/services.module';
+
+@Module({
+  imports: [AuthModule, ServicesModule],
+  controllers: [MonitoringController],
+  providers: [MonitoringService, PrismaService, UserService, JwtService],
+})
+export class MonitoringModule {}

--- a/src/monitoring/monitoring.service.ts
+++ b/src/monitoring/monitoring.service.ts
@@ -1,0 +1,263 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+import { LoggedUser } from 'src/auth/types';
+
+export interface HealthAlert {
+  id: string;
+  severity: 'CRITICA' | 'ALTA' | 'MEDIA' | 'BAJA';
+  entity: string;
+  count: number;
+  description: string;
+  affectedIds: string[];
+}
+
+@Injectable()
+export class MonitoringService {
+  constructor(private prisma: PrismaService) {}
+
+  async getHealthCheck(user: LoggedUser): Promise<HealthAlert[]> {
+    const ramaId = user.role === 'DIRIGENTE' ? user.id_rama : null;
+
+    const beneficiarioFilter = {
+      role: 'BENEFICIARIO' as const,
+      ...(ramaId && { id_rama: ramaId }),
+    };
+
+    const userBaseFilter = ramaId ? { id_rama: ramaId } : {};
+
+    // Pre-fetch family IDs in scope for DIRIGENTE
+    const familyIdsInScope = ramaId
+      ? (
+          await this.prisma.family.findMany({
+            where: { users: { some: { id_rama: ramaId } } },
+            select: { id: true },
+          })
+        ).map((f) => f.id)
+      : undefined;
+
+    const familyScopeFilter = familyIdsInScope
+      ? { id: { in: familyIdsInScope } }
+      : {};
+
+    const [
+      c1Users,
+      c2Users,
+      c3Users,
+      c5Families,
+      c7ActiveHistories,
+      a1Users,
+      a2Users,
+      a3Users,
+      a6Users,
+      m1Users,
+      m2Users,
+      m3Users,
+      m4Users,
+      m5Users,
+      familiesWithDetails,
+      m7Users,
+    ] = await Promise.all([
+      // C1: BENEFICIARIO sin familia
+      this.prisma.user.findMany({
+        where: { ...beneficiarioFilter, id_family: null },
+        select: { id: true },
+      }),
+      // C2: BENEFICIARIO sin rama (MASTER only)
+      ramaId
+        ? Promise.resolve([] as { id: string }[])
+        : this.prisma.user.findMany({
+            where: { role: 'BENEFICIARIO', id_rama: null },
+            select: { id: true },
+          }),
+      // C3: BENEFICIARIO sin familia ni rama (MASTER only)
+      ramaId
+        ? Promise.resolve([] as { id: string }[])
+        : this.prisma.user.findMany({
+            where: { role: 'BENEFICIARIO', id_family: null, id_rama: null },
+            select: { id: true },
+          }),
+      // C5: Familias sin usuario con role FAMILY
+      this.prisma.family.findMany({
+        where: {
+          ...familyScopeFilter,
+          users: { none: { role: 'FAMILY' } },
+        },
+        select: { id: true },
+      }),
+      // C7: Historial de ramas activo duplicado
+      this.prisma.userRamaHistory.findMany({
+        where: {
+          fecha_egreso: null,
+          ...(ramaId && { user: { id_rama: ramaId } }),
+        },
+        select: { id_user: true, id: true },
+      }),
+      // A1: Sin email (BENEFICIARIO y FAMILY)
+      this.prisma.user.findMany({
+        where: {
+          role: { in: ['BENEFICIARIO', 'FAMILY'] },
+          email: null,
+          ...userBaseFilter,
+        },
+        select: { id: true },
+      }),
+      // A2: Sin teléfono (BENEFICIARIO y FAMILY)
+      this.prisma.user.findMany({
+        where: {
+          role: { in: ['BENEFICIARIO', 'FAMILY'] },
+          phone: null,
+          ...userBaseFilter,
+        },
+        select: { id: true },
+      }),
+      // A3: Sin DNI
+      this.prisma.user.findMany({
+        where: { ...beneficiarioFilter, dni: null },
+        select: { id: true },
+      }),
+      // A6: DIRIGENTE sin rama (MASTER only)
+      ramaId
+        ? Promise.resolve([] as { id: string }[])
+        : this.prisma.user.findMany({
+            where: { role: 'DIRIGENTE', id_rama: null },
+            select: { id: true },
+          }),
+      // M1: Sin fecha de nacimiento
+      this.prisma.user.findMany({
+        where: { ...beneficiarioFilter, birthdate: null },
+        select: { id: true },
+      }),
+      // M2: Sin género
+      this.prisma.user.findMany({
+        where: { ...beneficiarioFilter, gender: null },
+        select: { id: true },
+      }),
+      // M3: Sin ciudadanía
+      this.prisma.user.findMany({
+        where: { ...beneficiarioFilter, citizenship: null },
+        select: { id: true },
+      }),
+      // M4: Sin dirección
+      this.prisma.user.findMany({
+        where: { ...beneficiarioFilter, address: null },
+        select: { id: true },
+      }),
+      // M5: Sin carpeta de documentos
+      this.prisma.user.findMany({
+        where: { ...beneficiarioFilter, id_folder: null },
+        select: { id: true },
+      }),
+      // Familias con balance para A4, A5, M6
+      this.prisma.family.findMany({
+        where: familyScopeFilter,
+        select: {
+          id: true,
+          phone: true,
+          balance: {
+            select: {
+              is_custom_cuota: true,
+              custom_cuota: true,
+              is_custom_cfa: true,
+              custom_cfa_value: true,
+            },
+          },
+        },
+      }),
+      // M7: Para validación de edad vs rango de rama
+      this.prisma.user.findMany({
+        where: {
+          ...beneficiarioFilter,
+          birthdate: { not: null },
+          id_rama: { not: null },
+        },
+        select: {
+          id: true,
+          birthdate: true,
+          rama: { select: { edad_min: true, edad_max: true } },
+        },
+      }),
+    ]);
+
+    // Procesar C4: familias sin usuarios (solo MASTER)
+    const c4Families = ramaId
+      ? []
+      : await this.prisma.family.findMany({
+          where: { users: { none: {} } },
+          select: { id: true },
+        });
+
+    // Procesar C7: usuarios con más de un historial activo
+    const c7Map = new Map<string, number>();
+    for (const h of c7ActiveHistories) {
+      c7Map.set(h.id_user, (c7Map.get(h.id_user) ?? 0) + 1);
+    }
+    const c7UserIds = [...c7Map.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([id]) => id);
+
+    // Procesar alertas de familias con balance
+    const a4Families = familiesWithDetails.filter(
+      (f) => f.balance?.is_custom_cuota && f.balance.custom_cuota === 0,
+    );
+    const a5Families = familiesWithDetails.filter(
+      (f) => f.balance?.is_custom_cfa && f.balance.custom_cfa_value === 0,
+    );
+    const m6Families = familiesWithDetails.filter((f) => !f.phone);
+
+    // Procesar M7: edad fuera del rango de la rama
+    const now = new Date();
+    const m7Affected = m7Users.filter((u) => {
+      if (!u.birthdate || !u.rama?.edad_min || !u.rama?.edad_max) return false;
+      const age = now.getFullYear() - new Date(u.birthdate).getFullYear();
+      return age < u.rama.edad_min || age > u.rama.edad_max;
+    });
+
+    // Construir arreglo de alertas
+    const alerts: HealthAlert[] = [];
+
+    const addAlert = (
+      id: string,
+      severity: HealthAlert['severity'],
+      entity: string,
+      description: string,
+      affected: { id: string }[] | string[],
+    ) => {
+      const ids =
+        affected.length === 0
+          ? []
+          : typeof affected[0] === 'string'
+            ? (affected as string[])
+            : (affected as { id: string }[]).map((a) => a.id);
+      if (ids.length > 0) {
+        alerts.push({ id, severity, entity, count: ids.length, description, affectedIds: ids });
+      }
+    };
+
+    // CRÍTICAS
+    addAlert('C1', 'CRITICA', 'User', 'Beneficiarios sin familia asignada', c1Users);
+    addAlert('C2', 'CRITICA', 'User', 'Beneficiarios sin rama asignada', c2Users);
+    addAlert('C3', 'CRITICA', 'User', 'Beneficiarios sin familia ni rama', c3Users);
+    addAlert('C4', 'CRITICA', 'Family', 'Familias sin ningún miembro', c4Families);
+    addAlert('C5', 'CRITICA', 'Family', 'Familias sin usuario administrador', c5Families);
+    addAlert('C7', 'CRITICA', 'UserRamaHistory', 'Usuarios con múltiples ramas activas simultáneas', c7UserIds);
+
+    // ALTAS
+    addAlert('A1', 'ALTA', 'User', 'Usuarios sin email registrado', a1Users);
+    addAlert('A2', 'ALTA', 'User', 'Usuarios sin teléfono registrado', a2Users);
+    addAlert('A3', 'ALTA', 'User', 'Beneficiarios sin DNI registrado', a3Users);
+    addAlert('A4', 'ALTA', 'Balance', 'Familias con cuota personalizada activa en cero', a4Families);
+    addAlert('A5', 'ALTA', 'Balance', 'Familias con CFA personalizado activo en cero', a5Families);
+    addAlert('A6', 'ALTA', 'User', 'Dirigentes sin rama asignada', a6Users);
+
+    // MEDIAS
+    addAlert('M1', 'MEDIA', 'User', 'Beneficiarios sin fecha de nacimiento', m1Users);
+    addAlert('M2', 'MEDIA', 'User', 'Beneficiarios sin género registrado', m2Users);
+    addAlert('M3', 'MEDIA', 'User', 'Beneficiarios sin ciudadanía registrada', m3Users);
+    addAlert('M4', 'MEDIA', 'User', 'Beneficiarios sin dirección registrada', m4Users);
+    addAlert('M5', 'MEDIA', 'User', 'Beneficiarios sin carpeta de documentos', m5Users);
+    addAlert('M6', 'MEDIA', 'Family', 'Familias sin teléfono de contacto', m6Families);
+    addAlert('M7', 'MEDIA', 'User', 'Beneficiarios cuya edad no corresponde al rango de su rama', m7Affected);
+
+    return alerts;
+  }
+}


### PR DESCRIPTION
Adds GET /monitoring/health-check that scans the database for incomplete or inconsistent data (missing family/rama assignments, orphaned families, corrupt rama history, invalid balance config, missing profile fields). Results are scoped by role: MASTER sees all, DIRIGENTE sees only their rama.